### PR TITLE
Reword Instant Trim description

### DIFF
--- a/b-and-w-radios/model-select/special-functions.md
+++ b/b-and-w-radios/model-select/special-functions.md
@@ -27,7 +27,7 @@ Below are all the available functions in EdgeTX, what they do, as well as what a
 
 * **Value** - Specifies which controls will be given over to the student. Options include **Sticks** (all sticks), **Rud** (Rudder), **Ele** (Elevator), **Thr** (Throttle), **Ail** (Aileron), and **Chans** (all channels).&#x20;
 
-**Inst. Trim** (Instant Trim)- Sets the current values of all sticks to their respective trims.
+**Inst. Trim** (Instant Trim)- Sets all trims to the current values of their respective sticks.
 
 **Reset** (Reset Timer)- Resets the timer or telemetry specified in the value back to their initial values.
 

--- a/edgetx-user-manual/user-manual-for-color-screen-radios/model-settings/special-functions.md
+++ b/edgetx-user-manual/user-manual-for-color-screen-radios/model-settings/special-functions.md
@@ -36,7 +36,7 @@ Below are all the available functions in EdgeTX, what they do, as well as what o
 
 * **Value** - Specifies which controls will be given over to the student. Options include **Sticks** (all sticks), **Rud** (Rudder), **Ele** (Elevator), **Thr** (Throttle), **Ail** (Aileron), and **Chans** (all channels).&#x20;
 
-**Inst. Trim** (Instant Trim)- Sets the current values of all sticks to their respective trims.
+**Inst. Trim** (Instant Trim)- Sets all trims to the current values of their respective sticks.
 
 **Reset** (Reset Timer)- Resets the timer or telemetry specified in the value back to their initial values.
 


### PR DESCRIPTION
The description of instant trim was really confusing, I had to find a video to find out what it does. But the function itself is pretty simple, it's just the description makes no sense.

Rewords the description of instant trim to make it clear that it is the trims being set, not the sticks.