### PR TITLE
Fixed typos and description order

### DIFF
--- a/b-and-w-radios/main-view/README.md
+++ b/b-and-w-radios/main-view/README.md
@@ -32,9 +32,9 @@ The main view is the default view normally used during radio operation. This vie
 
 **Screen 2** - This view displays the model name, trim positions (if trims are enabled), clock,  transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also has a graphical representation of the stick, pot, and switch positions.
 
-**Screen 3** - This view displays the model name, trim positions (if trims are enabled), clock,  transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also shows the numerical values of the output channels, 8 channels per page. Use the **\[Roller]**or **\[Dial]** to scroll thru the additional pages.&#x20;
+**Screen 3** - This view displays the model name, trim positions (if trims are enabled), clock,  transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also shows the values of output channels as a bar graph, 8 channels per page. Use the **\[Roller]** or **\[Dial]** to scroll thru the additional pages.&#x20;
 
-**Screen 4** - This view displays the model name, trim positions (if trims are enabled), clock,  transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also shows the values of output channels as a bar graph, 8 channels per page. Use the **\[Roller]** or **\[Dial]** to scroll thru the additional pages.&#x20;
+**Screen 4** - This view displays the model name, trim positions (if trims are enabled), clock,  transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also shows the numerical values of the output channels, 8 channels per page. Use the **\[Roller]**or **\[Dial]** to scroll thru the additional pages.&#x20;
 
 **Screen 5** - This view shows either the channel monitor or mixer monitor, 8 channels per page. Use the roller or dial to scroll thru the additional pages. Push the **\[Roller]** or **\[Dial]** button to switch between the channel monitor and mixer monitor.
 

--- a/b-and-w-radios/main-view/statistics.md
+++ b/b-and-w-radios/main-view/statistics.md
@@ -5,8 +5,8 @@
 The **Statistics** screen presents you with statistics regarding radio usage. All data is reset once the radio is powered off. The following information is provided:
 
 * **SES** - The amount of time that the radio has been turned on.&#x20;
-* **THR**  - The amount of time that the throttle has was above the 0% stick position.
-* **TH%** - The amount of time that the throttle has was above the 50% stick position.
+* **THR**  - The amount of time that the throttle has been above the 0% stick position.
+* **TH%** - The amount of time that the throttle has been above the 50% stick position.
 * **TM1/2/3** - The current values of Timer 1, Timer 2, and Timer 3.
 * **Throttle Graph** - Shows the throttle percentage over time.
 

--- a/b-and-w-radios/model-select/setup.md
+++ b/b-and-w-radios/model-select/setup.md
@@ -20,41 +20,41 @@ Image dimensions shall be 64 x 32 pixels, 16 bit, grayscale, .bmp file. The imag
 
 #### Timer 1   \[Mode]   \[Switch]&#x20;
 
-**\[Mode]**: The options include:
+**\[Mode]** - The options include:
 
-* **OFF**- The timer is not used
+* **OFF** - The timer is not used
 * **ON** - The timer runs all the time
-* **Strt (Start)** -The timer starts once the configured switch is activated. After the time is started, the timer ignores the switch position.
+* **Strt (Start)** - The timer starts once the configured switch is activated. After the time is started, the timer ignores the switch position.
 * **THs (Throttle)** - The timer starts once the throttle is raised and the configured switch is activated. The timer will stop counting if either the throttle position is lowered back to the minimum value or the configured switch is deactivated.
 * **TH% (Throttle %)** - The timer counts proportionally to the throttle. It counts in real-time at full throttle and half speed at 50% throttle.
 * **THt (Throttle Start)** - The timer starts once the throttle is raised and the configured switch is activated. After starting, the timer ignores the throttle position and will keep counting unless the switch is deactivated.
 
-**\[Switch]-** Select the switch that will trigger the timer to start.  If no switch is selected, the timer will trigger based only on the configured mode. In addition to a switch, you can also select a trim, a telemetry source (triggered when telemetry data is received from that source), or physical activity (stick movement or button press) (labeled as **ACT**)
+**\[Switch]** - Select the switch that will trigger the timer to start.  If no switch is selected, the timer will trigger based only on the configured mode. In addition to a switch, you can also select a trim, a telemetry source (triggered when telemetry data is received from that source), or physical activity (stick movement or button press) (labeled as **ACT**)
 
 {% hint style="info" %}
 Those items with a "!" mark in front of the trigger name mean that the condition is reversed. For example, "!SA-" means "when SA switch is not in middle/center position (= up or down)".
 {% endhint %}
 
-**Name:**  Name of the timer
+**Name:** - Name of the timer
 
-**Start-** The time used for the timer's advanced functions.  The default value is 00:00 and when left as such, the timer operates like a stopwatch, counting upward until stopped.  If a different time is entered in this box, then the additional field will appear next to the time with the options: **Remain** or **Elaps**.
+**Start** - The time used for the timer's advanced functions.  The default value is 00:00 and when left as such, the timer operates like a stopwatch, counting upward until stopped.  If a different time is entered in this box, then the additional field will appear next to the time with the options: **Remain** or **Elaps**.
 
 If set to **Remain**, the counter will function like a countdown timer - counting down from the designated time to zero and then alerting the user.  If set to **Elaps**, the timer functions like an alarm, counting up from zero until the designated time and then alerting the user.
 
-**Persist (Persistence):**
+**Persist. (Persistence):**
 
-* **Off** - The timer value is reset when switching models or when the radio is turned off / on.
+* **OFF** - The timer value is reset when switching models or when the radio is turned off / on.
 * **Flight** - The timer value is NOT reset when switching models or when the radio is turned off / on. The timer value is only reset when the **Reset flight** option is selected in the [Reset](../main-view/reset.md) menu.
-* **Manual Reset -** The timer value is reset only when it is individually selected to be reset (example: Reset timer1) in the [Reset](../main-view/reset.md) menu.
+* **Manual Reset** - The timer value is reset only when it is individually selected to be reset (example: Reset timer1) in the [Reset](../main-view/reset.md) menu.
 
 **Minute (Minute Call)** - If selected, you will be notified every minute that passes as described in the **Count Down** option.
 
-**Count Down:**
+**Countdown:**
 
 * **Silent** - No notification is given until the timer reaches zero. When it reaches zero, you will hear one beep.
 * **Beeps** - The radio will beep every second starting at the time designated.
 * **Voice** - The radio will count down by second starting at the time designated.
-* **Haptic** -The radio will vibrate every second starting at the time designated.
+* **Haptic** - The radio will vibrate every second starting at the time designated.
 
 <figure><img src="../../.gitbook/assets/Bwsetup1.png" alt=""><figcaption><p>Function Switches</p></figcaption></figure>
 
@@ -67,7 +67,7 @@ Unlike other switches managed at the radio level, function switches are defined 
 **Switch Type**
 
 * **None**: the switch is disabled
-* **Toggle** : they are active only during the push duration
+* **Toggle**: they are active only during the push duration
 * **2POS**: pushing the switch will alternate the state between OFF and On
 
 **Switch group**
@@ -84,7 +84,7 @@ Selecting this check box makes the assigned group act like a traditional 6-posit
 
 **Startup Position**
 
-**Start -** Defines the state that each switch will be in when the model is loaded.
+**Start** - Defines the state that each switch will be in when the model is loaded.
 
 * **↑** Switch is inactive
 * **↓** Switch is active
@@ -100,13 +100,13 @@ Unlike hardware 6-POS implementation (Horus, TX16S,...), software managed switch
 
 **E.Limits (Extended Limits)** - When enabled, it increases the minimum and maximum range for the output values to -150 and 150. Extended limits are necessary if the full range of the control surface cannot be reached with standard limits.
 
-**E. Trims) Extended Trims**: Increases the maximum trim adjustment value from **±**25% to **±**100%.
+**E.Trims (Extended Trims)** - Increases the maximum trim adjustment value from **±**25% to **±**100%.
 
 **Reset** - This resets all trim values to zero.
 
-**Show trims:** When set to **Yes**, it will display the numerical trim value on the trim bar.  When set to **CHANGE**, it will display the numerical value once the trim is no longer at zero.
+**Show trims** - When set to **Yes**, it will display the numerical trim value on the trim bar.  When set to **Change**, it will display the numerical value once the trim is no longer at zero.
 
-**Trim Step:** Defines the amount of increase/decrease in trim when the trim switch is pressed.&#x20;
+**Trim Step** - Defines the amount of increase/decrease in trim when the trim switch is pressed.&#x20;
 
 * Course = 1.6%
 * Medium = 0.8%
@@ -120,17 +120,17 @@ Unlike hardware 6-POS implementation (Horus, TX16S,...), software managed switch
 
 The throttle related configuration options below are displayed in collapsible menu.
 
-**T-Reverse:** When enabled, this option reverses the output direction of the configured throttle channel.
+**T-Reverse** - When enabled, this option reverses the output direction of the configured throttle channel.
 
-**T-Source:** The source that will be used for the throttle.&#x20;
+**T-Source** - The source that will be used for the throttle.&#x20;
 
-**T-Trim-Idle**: When enabled, the throttle trim will only affect the bottom portion of the throttle band.&#x20;
+**T-Trim-Idle** - When enabled, the throttle trim will only affect the bottom portion of the throttle band.&#x20;
 
 {% hint style="info" %}
 For example, with **Trim idle only** enabled, the throttle stick at the lowest point might have a value of -80 and the center point will still be 0 and the highest point of 100. Without this enabled, the throttle stick at the lowest point might have a value of -80 however, the center point will be 20 and the highest point of 100.&#x20;
 {% endhint %}
 
-**T-Trim-SW:** The trim switch that will be used to trim the throttle. It is possible to substitute the throttle trim switch with the aileron, rudder, or elevator trim switches.
+**T-Trim-Sw** - The trim switch that will be used to trim the throttle. It is possible to substitute the throttle trim switch with the aileron, rudder, or elevator trim switches.
 
 <figure><img src="../../.gitbook/assets/bwsetup4 (1).png" alt=""><figcaption><p>Preflight Checks options</p></figcaption></figure>
 
@@ -138,27 +138,27 @@ For example, with **Trim idle only** enabled, the throttle stick at the lowest p
 
 Whenever a new model is loaded, EdgeTX will conduct pre-flight checks based on the checks that are configured on this page. If any of the checks are failed, EdgeTX will give the user an audio and visual warning that must be acknowledged before using the model. The following preflight checks below are displayed in collapsible menu.
 
-**Checklist** - When this option is selected, the model notes file will be displayed when the model is loaded. A valid model notes file must be in the **Models** folder on the SD card. The model notes file must be a .txt file and must have the EXACT same name as the model it is for, for example: Mobula6.txt. The text in the file is up to the user.
+**Checklist** - When this option is selected, the model notes file will be displayed when the model is loaded. A valid model notes file must be in the **Models** folder on the SD card. The model notes file must be a .txt file and must have the exact same name as the model it is for, for example: Mobula6.txt. The text in the file is up to the user.
 
 **T-Warning** - When selected, the radio will check that the throttle is at the minimum value for the configured throttle source in the **T-Source** configuration option.
 
-**Cust-Pos** - When this option is selected, the value designated in **POS.%** will be used for the T.Warning.
+**Cust-Pos** - When this option is selected, the value designated in **Pos. %** will be used for the **T.Warning**.
 
-**Pos.%** - minimum value of the throttle for the throttle warning when **Cust-Pos** is enabled.
+**Pos. %** - minimum value of the throttle for the throttle warning when **Cust-Pos** is enabled.
 
 **S-Warning** - The section displays all the switches that are configured on the radio and allows you to select which position is the correct position for the switch state check. Selecting the switch will cycle through the available switch positions or turn the check off for the switch completely.
 
-**Pot warn**- When activated, this option checks the position of the pots & sliders. There are three options - OFF, ON and AUTO. When ON or AUTO is selected, buttons for the available pots and sliders will appear. To enable the Pot warning for an individual Pot, select the pot with the \[roller] or \[dial] and click the button to highlight it.  Highlighted pots are enabled.
+**Pot warn.** - When activated, this option checks the position of the pots & sliders. There are three options - **OFF**, **Man** and **Auto**. When **ON** or **AUTO** is selected, buttons for the available pots and sliders will appear. To enable the pot warning for an individual pot, select the pot with the **\[roller]** or **\[dial]** and click the button to highlight it. Highlighted pots are enabled.
 
 * **OFF** - Pot and slider positions are not checked.
-* **Manual** - Positions are checked against manually configured pot and slider positions. To manually set the check position, select **manual** the from menu, select the item that you want to set, and long-press the **\[Enter]** button to set its current position for the check.&#x20;
-* **AUTO** - Positions are checked for pots and sliders and compared to the last automatically saved position before the radio was turned off or the model was changed.
+* **Man** - Positions are checked against manually configured pot and slider positions. To manually set the check position, select **manual** the from menu, select the item that you want to set, and long-press the **\[Enter]** button to set its current position for the check.&#x20;
+* **Auto** - Positions are checked for pots and sliders and compared to the last automatically saved position before the radio was turned off or the model was changed.
 
 **Ctr Beep** - Allows you to turn on/off the center beep function for the individual sticks, pots, and sliders by highlighting them with the **\[roller]** or **\[dial]** and pressing the button. When a switch is highlighted, the function is enabled.
 
-**Glob. Funs** - When enabled, global functions programmed in the radio settings will apply to this model. When disabled, global functions will not apply to this model.
+**Glob.Funcs** - When enabled, global functions programmed in the radio settings will apply to this model. When disabled, global functions will not apply to this model.
 
-**ADC Filter** - Enables/disables the ADC filter for this model. The _**global**_ option will take the value designated in the radio settings, which is _on_ by default.
+**ADC filter** - Enables/disables the ADC filter for this model. The **Global** option will take the value designated in the radio settings, which is _on_ by default.
 
 {% hint style="info" %}
 The ADC filter is a filter for the proportional channels (sticks, pots, sliders), smoothing out smaller fast movements that occur due to noise in the system electronics. Normally, this filter should be _disabled_ for models with flight controllers.
@@ -168,13 +168,13 @@ The ADC filter is a filter for the proportional channels (sticks, pots, sliders)
 
 The configuration settings for both the Internal and External RF sections work the same. The only difference is that the **Internal RF** section is for configuring the built-in module and the **External RF** section is for configuring an RF module in the external module bay.
 
-The configuration options are: _**off**_ or the _**module name**_ of the installed module as configured in the _**Radio**_ settings. Configuration options are unique to each installed module. Please consult the manufacturer's documentation for configuration options.&#x20;
+The configuration options are: **OFF** or the _**module name**_ of the installed module as configured in the radio settings. Configuration options are unique to each installed module. Please consult the manufacturer's documentation for configuration options.&#x20;
 
 {% hint style="info" %}
 Configuration options for the multi-protocol module are described here:  [https://www.multi-module.org/using-the-module/protocol-options](https://www.multi-module.org/using-the-module/protocol-options)
 {% endhint %}
 
-**Receiver number** - A receiver number is a user-assigned number for a model that is sent to the receiver when bound. Each model must have a unique receiver number. However, models using different protocols may have the same receiver number without issues.  EdgeTX will inform you when a receiver number is unique or if it is already being used with a text above the number field.
+**Receiver number** - A receiver number is a user-assigned number for a model that is sent to the receiver when bound. Each model must have a unique receiver number. However, models using different protocols may have the same receiver number without issues. EdgeTX will inform you when a receiver number is unique or if it is already being used with a text above the number field.
 
 {% hint style="info" %}
 If using the radio in gamepad mode, both internal and external RF modules should be turned off. This will result in increased performance when connected to a computer via USB.&#x20;
@@ -182,7 +182,7 @@ If using the radio in gamepad mode, both internal and external RF modules should
 
 ### **Trainer**
 
-**Trainer Mode** - The **Trainer** **Mode** option is where you can configure the CPPM passthrough mode and method.  When enabled, this allows the CPPM signals from a radio in _**Slave**_ mode to be passed through to another radio in Master mode which will then pass the signal to the model it is connected to. CPPM passthrough can be used for several different use cases, such as: connecting a head tracker, Instructor / Student training mode, and controlling complex models that require more stick inputs than available on a standard transmitter.&#x20;
+**Trainer Mode** - The **Trainer Mode** option is where you can configure the CPPM passthrough mode and method.  When enabled, this allows the CPPM signals from a radio in _**Slave**_ mode to be passed through to another radio in Master mode which will then pass the signal to the model it is connected to. CPPM passthrough can be used for several different use cases, such as: connecting a head tracker, Instructor / Student training mode, and controlling complex models that require more stick inputs than available on a standard transmitter.&#x20;
 
 **Master mode** - This is the mode for the radio that will be connected to the model. This radio also shall configure the special/global function (Trainer) to activate the passthrough mode. When the passthrough mode is activated, the CPPM signals from the radio in _**Slave mode**_ will be sent to the model for control.
 
@@ -190,11 +190,11 @@ If using the radio in gamepad mode, both internal and external RF modules should
 
 Below are the possibile configuration options:
 
-* **Off** - Trainer mode is not used for this model.&#x20;
-* **Master / Jack** - Master mode using a cable connection.
-* **Slave / Jack** - Slave mode using a cable connection.
-  * **Channel Range** - This is the range of channels that will be sent to the radio in Master mode. Channel 10 is the recommended last channel to use.
-  * **PPM Frame** - The first field is the length of the PPM frame. The second field is the stop length/delay between pulses. The dropdown is to select the polarity of the signal. The frame length is automatically adjusted to the correct value when the number of transmitted channels is changed. However, this automatically assigned value can be manual changed. _**Note**: In most cases, the default setting does_ not _need to be changed._
+* **OFF** - Trainer mode is not used for this model.&#x20;
+* **Master/Jack** - Master mode using a cable connection.
+* **Slave/Jack** - Slave mode using a cable connection.
+  * **Ch. Range** - This is the range of channels that will be sent to the radio in Master mode. Channel 10 is the recommended last channel to use.
+  * **PPM frame** - The first field is the length of the PPM frame. The second field is the stop length/delay between pulses. The dropdown is to select the polarity of the signal. The frame length is automatically adjusted to the correct value when the number of transmitted channels is changed. However, this automatically assigned value can be manual changed. _**Note**: In most cases, the default setting does_ not _need to be changed._
 * **Master / Bluetooth** - Master mode using a Bluetooth connection (if installed in radio).
 * **Slave / Bluetooth** - Slave mode using a Bluetooth connection (if installed in radio).
 * **Master / Multi** - Master mode using an additional externally mounted Multi-protocol module for the connection. For more information on this setup, see [set-up-wireless-trainer-with-mpm.md](../../edgetx-how-to/set-up-wireless-trainer-with-mpm.md "mention")
@@ -223,10 +223,10 @@ The **USB Joystick** has two possible modes, **Classic** and **Advanced**.&#x20;
 
 In **Classic mode**, the radio's configured output channels will be sent to the target device in numerical order and mapped to the device's preconfigured USB controller axes and buttons. Below is the default channel mapping for Microsoft Windows.
 
-* Ch1 - X Axis
+* Ch 1 - X Axis
 * Ch 2 - Y Axis
 * Ch 3 - Z Axis
-* Ch4 - X Rotation
+* Ch 4 - X Rotation
 * Ch 5 - Y Rotation
 * Ch 6 - Z Rotation
 * Ch 7 - Dial
@@ -235,46 +235,46 @@ In **Classic mode**, the radio's configured output channels will be sent to the 
 
 In **Advanced mode** you can configure the following additional options:
 
-**If mode (Interface mode):** This indicates to the target device (the device you are connecting your transmitter to) what type of device you are connecting. The options are **Joystick**, **Gamepad**, **MultiAxis.** &#x20;
+**If. mode (Interface mode):** This indicates to the target device (the device you are connecting your transmitter to) what type of device you are connecting. The options are **Joystick**, **Gamepad**, **MultiAxis.** &#x20;
 
 {% hint style="info" %}
 **Note:** Currently there is a limitation in MS Windows that may limit your transmitter to being only detected only as a Joystick, regardless of what is selected in this option. In MacOS, Linux and Andriod this functions properly.
 {% endhint %}
 
-**Circular cutout**: For axis pairs (X-Y, Z-rX): By default, the range of the axis pairs is a rectangular area. With this option, the axis will be limited to a circular area (like gamepad controllers commonly are). Options are : **None** or **X-Y, Z-rX** or **X-Y, Rx-Ry**
+**Circ. cut (Circular cutout)** - For axis pairs (X-Y, Z-rX): By default, the range of the axis pairs is a rectangular area. With this option, the axis will be limited to a circular area (like gamepad controllers commonly are). Options are : **None** or **X-Y, Z-rX** or **X-Y, Rx-Ry**
 
 **Channel Settings**
 
-**Mode**: For each output channel, you can select the mode that you want to use for that channel. The available options are **None**, **Btn**, **Axis**, **Sim**.
+**Mode** - For each output channel, you can select the mode that you want to use for that channel. The available options are **None**, **Btn**, **Axis**, **Sim**.
 
-**None** - Channel is not used
+* **None** - Channel is not used
 
 <figure><img src="../../.gitbook/assets/bwjoy1.png" alt=""><figcaption><p>Button mode options for a selected channel</p></figcaption></figure>
 
-**Btn** - Channel is used to simulate a button. Configuration options include:
+* **Btn** - Channel is used to simulate a button. Configuration options include:
 
-* **Inversion** - Inverts the output channel signal. Options are: **On** / **Off**
-* **Button Mode** -
-  * **Normal** - Each postion of a multiposition switch is represented by a button. The current switch state is represented by a continous button press.
-  * **Pulse** - Similar to "Normal" mode. However, instead of continous button press it is represented by a short button press.
-  * **SWEmu** - The toggle switch emulations a push button. The first press turns the virtual button on, the second press turns it off.
-  * **Delta** - The change of the output channel is represented by 2 buttons. While the output value is decreasing, the first button is pressed. When the output value is increasing, the second button is pressed. If there is no change, then no buttons will be pressed.
-  * **Companion** - This option should be selected when using your transmitter to control the simulator in EdgeTX Companion.  It allows the multi-position switches to function properly in the simulator.
-* **Positions** - The type of button that will be simulated.&#x20;
-  * **Push -** will only map to one button
-  * **2POS - 8 POS** - will map to the number of buttons that the switch has (ex: 3POS will map to 3 buttons).
-* **Button No:** The button number that the output will be mapped to and sent to the target device as.
+  * **Inversion** - Inverts the output channel signal. Options are: **On** / **Off**
+  * **Button Mode**
+    * **Normal** - Each postion of a multiposition switch is represented by a button. The current switch state is represented by a continous button press.
+    * **Pulse** - Similar to "Normal" mode. However, instead of continous button press it is represented by a short button press.
+    * **SWEmu** - The toggle switch emulations a push button. The first press turns the virtual button on, the second press turns it off.
+    * **Delta** - The change of the output channel is represented by 2 buttons. While the output value is decreasing, the first button is pressed. When the output value is increasing, the second button is pressed. If there is no change, then no buttons will be pressed.
+    * **Companion** - This option should be selected when using your transmitter to control the simulator in EdgeTX Companion.  It allows the multi-position switches to function properly in the simulator.
+  * **Positions** - The type of button that will be simulated.&#x20;
+    * **Push** - will only map to one button
+    * **2POS - 8 POS** - will map to the number of buttons that the switch has (ex: 3POS will map to 3 buttons).
+  * **Button No** - The button number that the output will be mapped to and sent to the target device as.
 
 <figure><img src="../../.gitbook/assets/bwjoy2.png" alt=""><figcaption><p>Axis mode options for a selected channel</p></figcaption></figure>
 
-**Axis -** The channel is used to simulate an axis and will be mapped to one of the target device's default axes.
+* **Axis** - The channel is used to simulate an axis and will be mapped to one of the target device's default axes.
 
-* Axis options are: X, Y, Z, rotX (rotation x), rotY, rotZ
+  * Axis options are: **X**, **Y**, **Z**, **rotX** (rotation X), **rotY**, **rotZ**
 
 <figure><img src="../../.gitbook/assets/bwjoy3.png" alt=""><figcaption><p>Sim mode options for selected channel</p></figcaption></figure>
 
-**Sim -** The channel is used to simulate a common sim axis and it will be listed on the target device as the selected option (ex: Thr)
+* **Sim** - The channel is used to simulate a common sim axis and it will be listed on the target device as the selected option (ex: Thr)
 
-* Sim Axis options are: **Ail**, **Ele**, **Rud**, **Thr**
+  * Sim Axis options are: **Ail**, **Ele**, **Rud**, **Thr**
 
 Pressing the **\[PAGE>]** button will take you to the **Heli Setup** screen.


### PR DESCRIPTION
In the BW Main View, the Screen 3 has bar graphs and Screen 4 - numerical values

Also normalized option-description separator format in the BW Models/Setup page,
adapted options names according to the UI and EdgeTX latest code constants