### PR TITLE
GITBOOK-5: main-view-screen2-logical-switches

### DIFF
--- a/bw-radios/main-view/README.md
+++ b/bw-radios/main-view/README.md
@@ -2,8 +2,6 @@
 
 The main view is the default view normally used during radio operation. This view displays information such as the model name, trim positions, transmitter battery voltage, flight mode, receiver signal strength, and Timers. A clock is also displayed in the center of the lower portion of all screens. There are five main view screens.
 
-
-
 <div>
 
 <figure><img src="../../.gitbook/assets/bwview1.png" alt=""><figcaption><p>Screen 1</p></figcaption></figure>
@@ -36,9 +34,9 @@ The main view is the default view normally used during radio operation. This vie
 
 **Screen 1** - This view displays the model name, trim positions (if trims are enabled), clock, transmitter battery voltage, flight mode, receiver signal strength, and Timers 1 and 2 (if enabled).
 
-**Screen 2** - This view displays the model name, trim positions (if trims are enabled), clock,  transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also has a graphical representation of the stick, pot, and switch positions.
+**Screen 2** - This view displays the model name, trim positions (if trims are enabled), clock, transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also has a graphical representation of the stick, pot, and switch positions. Use the **\[Roller]** or **\[Dial]** to scroll thru the additional pages. The second page shows the state of the [logical switches](../model-select/logical-switches.md).
 
-**Screen 3** - This view displays the model name, trim positions (if trims are enabled), clock,  transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also shows the values of output channels as a bar graph, 8 channels per page. Use the **\[Roller]**or **\[Dial]** to scroll thru the additional pages.&#x20;
+**Screen 3** - This view displays the model name, trim positions (if trims are enabled), clock, transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also shows the values of output channels as a bar graph, 8 channels per page. Use the \*\*\[Roller]\*\*or **\[Dial]** to scroll thru the additional pages.
 
 **Screen 4** - This view displays the model name, trim positions (if trims are enabled), clock, transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also shows the numerical values of the output channels, 8 channels per page. Use the **\[Roller]** or **\[Dial]** to scroll thru the additional pages.
 
@@ -50,4 +48,3 @@ Long pressing the **\[Roller]** or **\[Dial]** button from the main view screen 
 * **Reset** - See [Reset](reset.md) page.
 * **Statistics** - See [Statistics](statistics.md) page.
 * **About** - Displays the EdgeTX firmware version being used by the radio.
-


### PR DESCRIPTION
add note for the 2nd subpage on main screen 2 which shows the state of the logical switches.