### PR TITLE
add note for screen2 page 2 for logical switches

### DIFF
--- a/bw-radios/main-view/README.md
+++ b/bw-radios/main-view/README.md
@@ -36,7 +36,7 @@ The main view is the default view normally used during radio operation. This vie
 
 **Screen 1** - This view displays the model name, trim positions (if trims are enabled), clock, transmitter battery voltage, flight mode, receiver signal strength, and Timers 1 and 2 (if enabled).
 
-**Screen 2** - This view displays the model name, trim positions (if trims are enabled), clock,  transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also has a graphical representation of the stick, pot, and switch positions.
+**Screen 2** - This view displays the model name, trim positions (if trims are enabled), clock,  transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also has a graphical representation of the stick, pot, and switch positions. Use the **\[Roller]** or **\[Dial]** to scroll thru the additional pages. The second page shows the state of the [logical switches](../model-select/logical-switches.md).
 
 **Screen 3** - This view displays the model name, trim positions (if trims are enabled), clock,  transmitter battery voltage, flight mode, receiver signal strength, and Timer 1 (if enabled). It also shows the values of output channels as a bar graph, 8 channels per page. Use the **\[Roller]**or **\[Dial]** to scroll thru the additional pages.&#x20;
 


### PR DESCRIPTION
add note for the 2nd subpage on main screen 2 which shows the state of the logical switches.