### PR TITLE
rotary seems to change case on b&w

### DIFF
--- a/bw-radios/user-inteface.md
+++ b/bw-radios/user-inteface.md
@@ -21,3 +21,7 @@ The buttons below are commonly used to navigate EdgeTX. If your radio does not h
 * **\[Enter]** - Accept \
   \- Used to select option, function or accept value\
   \- Push **\[Roller]** or **\[Dial]** button to select or enter.
+
+#### **Text Editing:***
+
+When editing text, you can often hold down **[Roller]** or **[Dial]** to change the between uppper and lower case.


### PR DESCRIPTION
I saw a question on "RadioMaster MT12 Tips & Tricks" facebook group:

> Silly question...
> After updating the firmware (latest), I no longer have capital letters available for naming the models. Its not a terribly bit deal, just annoying, how do I get the caps back?

I have an MT12, and I thought the caps are after all the lower case, maybe this has changed, maybe not. However I did stumble upon holding down the rotary (enter) to change case, which is not necessarily obvious and is undocumented.

I've looked in the source (the best I can) and found [this](https://github.com/EdgeTX/edgetx/blob/47cba2211f524db5f78d7d5fd89843b71ccedada/radio/src/gui/common/stdlcd/draw_functions.cpp#L232) which seems to hint that it's on all radios, but I'm not sure, for now I'm betting it's at least B&W, so have created this PR for the B&W manual.

Happy to update color as well and / or change styling if I'm not following the correct form.